### PR TITLE
Add GitHub issue templates ported from TABConf 7

### DIFF
--- a/.github/ISSUE_TEMPLATE/builder-day-project-submission.md
+++ b/.github/ISSUE_TEMPLATE/builder-day-project-submission.md
@@ -1,0 +1,25 @@
+---
+name: 'Builder Day Project Submission'
+about: Submit your Builder Day Project for TABConf 8!
+title: 'Builder Days Project <<projectname>>'
+labels: Builders Day Project
+assignees: ''
+
+---
+
+<!-- All software-based projects submitted must be open source and freely available for public use -->
+
+## Project
+#### Description:
+#### Link(s) to source Repos:
+#### What would an attendee learn from visiting this projects table at Builder Days?
+#### What should people read up on before finding the table at Builder Day?
+<!-- Set Expectations! Builder Days run October 12-13, 2026. Will you be doing this for both days? Will you plan to be around all day? -->
+#### Schedule:
+<!-- Are contributors or maintainers available who can answer questions and get people onboarded? Who will be helping run the table area? -->
+#### Builder Table Staff: 
+<!-- Space: Will you require an elaborate setup or additional space? The usual expectation is to move a few tables together to create a builder space. Replace "normal setup" with a suggestion to start the discussion. -->
+#### Space: normal setup
+#### Other Relevant Links:
+
+#### Additional Project Details

--- a/.github/ISSUE_TEMPLATE/conference-idea.md
+++ b/.github/ISSUE_TEMPLATE/conference-idea.md
@@ -1,0 +1,13 @@
+---
+name: Conference Idea
+about: Suggest an idea for TABConf 8
+title: Idea - <<ideaName>>
+labels: Conference Suggestion
+assignees: ''
+
+---
+
+# Description
+### What is this idea? Give us as many details as possible. 
+### What would an attendee gain from this?
+### Relevant Links

--- a/.github/ISSUE_TEMPLATE/panel-discussion-submission.md
+++ b/.github/ISSUE_TEMPLATE/panel-discussion-submission.md
@@ -1,0 +1,30 @@
+---
+name: Panel Discussion Submission
+about: Submit your panel discussion idea for TABConf 8!
+title: ''
+labels: Panel
+assignees: ''
+
+---
+
+# Description
+### What is this panel discussion about? Will there be multiple talking points?
+### What would an attendee learn from this panel?
+### Is there anything folks should read up on before they attend?
+### Relevant Links
+
+<!-- leave blank if you are unsure, this list can change -->
+### Moderator: 
+<!-- leave blank if you are unsure, this list can change -->
+### Panelists:
+<!-- list Names, Social Links, GitHub, Twitter, Website -->
+
+<!-- If you're unsure who will be organizing the panel and want the TABConf staff to handle it, please indicate that here. -->
+### Who will be helping organize this panel?
+
+
+# Panel Details
+### Length of the panel discussion
+### Preferred Day/Time Slot 
+<!-- Conference sessions run October 14-15, 2026. -->
+*We will do our best to accommodate your requested time slot. Please let us know if there are any dates/times that ***absolutely do not work*** for you.*

--- a/.github/ISSUE_TEMPLATE/satellite-event-submission.md
+++ b/.github/ISSUE_TEMPLATE/satellite-event-submission.md
@@ -1,0 +1,19 @@
+---
+name: Satellite Event Submission
+about: Submit your Satellite Event that you're organizing around the time of TABConf 8!
+title: Satellite Event - <<eventName>>
+labels: Satellite Event
+assignees: ''
+
+---
+
+<!-- TABConf 8 is October 12-15, 2026 in Atlanta. Satellite events are organized independently, not run by TABConf. -->
+
+# Description
+### Event Description
+### Date and time
+### Location
+### Anything people should know before coming?
+<!-- Ticketed or free? RSVP required? Capacity limits? -->
+### Relevant Links
+<!-- Registration/RSVP link, site, social. Accepted events may be listed on 8.tabconf.com. -->

--- a/.github/ISSUE_TEMPLATE/solo-talk-submission.md
+++ b/.github/ISSUE_TEMPLATE/solo-talk-submission.md
@@ -1,0 +1,28 @@
+---
+name: Solo Talk Submission
+about: Submit your talk idea for TABConf 8!
+title: ''
+labels: Talk
+assignees: ''
+
+---
+
+<!-- Doing a non-interactive demo? That belongs here, not under "Workshop Submission". -->
+
+# Description
+### What is this talk about? Give us as many details as possible. 
+### What would an attendee learn from this talk?
+### Is there anything folks should read up on before they attend this talk?
+### Relevant Links
+
+# About the Speaker
+### Social Links
+Github 
+Twitter
+Website
+
+# Talk Details
+### Length of Talk
+### Preferred Day/Time Slot 
+<!-- Conference sessions run October 14-15, 2026. -->
+*We will do our best to accommodate your requested time slot. Please let us know if there are any dates/times that ***absolutely do not work*** for you.*

--- a/.github/ISSUE_TEMPLATE/website-update-needed.md
+++ b/.github/ISSUE_TEMPLATE/website-update-needed.md
@@ -1,0 +1,15 @@
+---
+name: 'Website Update Needed'
+about: Suggest a change or report a problem on 8.tabconf.com
+title: 'website change'
+labels: website
+assignees: ''
+
+---
+
+## Website change
+#### Page(s) affected
+<!-- Link the page on 8.tabconf.com, or the file in this repo. -->
+#### Description of suggested change or needed addition
+#### Screenshots
+<!-- Optional. Helpful for layout and mobile issues. Include browser/device if it's a display bug. -->

--- a/.github/ISSUE_TEMPLATE/workshop-submission.md
+++ b/.github/ISSUE_TEMPLATE/workshop-submission.md
@@ -1,0 +1,35 @@
+---
+name: Workshop Submission
+about: Submit your workshop idea for TABConf 8!
+title: ''
+labels: Workshop
+assignees: ''
+
+---
+
+<!-- NOTE!! If you are intending to do a non-interactive demo, THIS IS NOT a workshop, please submit talk demo's under "Solo Talks". -->
+
+# Description
+### What is this workshop about? Provide as many details as possible. 
+### What would an attendee learn from this workshop?
+### Is there anything attendees should read up on before they attend this workshop?
+### Is there anything attendees should set up before the workshop?
+<!-- Laptops, dependencies installed, testnet/signet coins, hardware, accounts, etc. -->
+### Relevant Links
+
+<!-- PLEASE READ!!! Set expectations for participants! Will this be for "Beginner"s? (No prior knowledge needed, very few technical skills required for workshop? "Intermediate"? At least some knowledge needed to not be lost, technical skills, Comp Sci, IT related experience is greatly beneficial? Will this be "Advanced"? meaning skills required in specific technologies required in order for participants to be successful. Potentially a strong working knowledge of certain technologies, libraries, fundamentals, and protocols. --> 
+
+# Level of difficulty 
+<!-- Please put "Beginner", "Intermediate", or "Advanced". If in doubt err on the side of setting expectations that it will be harder. Workshop space may be limited and we don't want to accidentally fill people into a workshop that isn't for them. --> 
+
+# About the Speaker
+### Social Links
+Github 
+Twitter
+Website
+
+# Workshop Details
+### Length of workshop
+### Preferred Day/Time Slot 
+<!-- Builder Days and workshops run October 12-13, 2026. -->
+*We will do our best to accommodate your requested time slot. Please let us know if there are any dates/times that ***absolutely do not work*** for you.*


### PR DESCRIPTION
Carries over the seven issue templates from 7.tabconf.com so speakers, workshop leads, and attendees have a structured starting point again.

Adapted for TABConf 8:
- Day/slot hints reference the Oct 12-15, 2026 schedule (Builder Days and workshops Oct 12-13, conference sessions Oct 14-15)
- Builder Day template uses this repo's 'Builders Day Project' label spelling
- Conference Idea labeled 'Conference Suggestion' and no longer auto-assigns
- Fixed the mangled 'about:' line on the solo talk template
- Workshop template asks about the workshop, not 'this talk'
- Website template drops a stray copy-pasted open-source note and asks for the affected page

Closes #23